### PR TITLE
[DOI-1178] Replace tinyMCE.getContent() function for value of element

### DIFF
--- a/admin/js/doppler-form-admin.js
+++ b/admin/js/doppler-form-admin.js
@@ -567,11 +567,8 @@ function validateEmailContent(e) {
 	if (!tinyMCE.activeEditor)
 		jQuery(".wp-editor-wrap .switch-tmce").trigger("click");
 
-	if (!tinyMCE.activeEditor) {
-		content = document.getElementById("content").value;
-	} else {
-		content = tinyMCE.activeEditor.getContent();
-	}
+	// get content by element Id because sometimes the tinyMCE.getContent() function is not updated
+	content = document.getElementById("content").value;
 
 	content = content.replace(
 		'href="[[[ConfirmationLink]]]"',
@@ -582,7 +579,7 @@ function validateEmailContent(e) {
 		"href=[[[ConfirmationLink]]]"
 	);
 
-	if (!tinyMCE.activeEditor) {
+	if (tinyMCE.activeEditor) {
 		tinyMCE.activeEditor.setContent(content);
 	} else {
 		document.getElementById("content").value = content;


### PR DESCRIPTION
There is an event triggering when the editor is on blur. The thing is, when this event was being triggered if we want to get the editor content trough it's proper function getContent() it would return an updated content.
For that reason I'm changing that to returning the content by its element ID.

This fixes the issue when editing from the HTML section of the editor, 
@blancfabian Please let me know what you think of this approach.