### PR TITLE
[DOI-1240] Display consent field correctly on horizontal forms

### DIFF
--- a/includes/helpers/Form_Helper.php
+++ b/includes/helpers/Form_Helper.php
@@ -34,14 +34,11 @@ class DPLR_Form_helper
 				$label = isset($field->settings['label']) ? $field->settings['label'] : $field->name;?>
 				<div class="<?php echo ($field->type !== "permission") ? "flex-item" : ""; ?> input-field <?php echo isset($field->settings['required']) ? 'required' : ''; ?>">
 					<?php if($label!==''): ?>
-						<?php if($field->type === 'permission'): ?>
-							<label for="<?php echo $field->name; ?>" >
+						<?php if($field->type !== 'permission'): ?>
+							<label for="<?php echo $field->name; ?>" class="horizontal_label" >
 								<?php echo $label; ?>
 							</label>
 						<?php endif; ?>
-						<label for="<?php echo $field->name; ?>" class="horizontal_label" >
-							<?php echo $label; ?>
-						</label>
 					<?php endif;
 					if($field->type !== 'permission'):
 						echo self::printInput($field, $form, $label, $form_orientation_horizontal);


### PR DESCRIPTION
Before:
![image](https://github.com/FromDoppler/Wordpress-Plugin-Doppler/assets/34007887/d504771d-6285-4250-958a-0ff623b8efe2)

Now:
![image](https://github.com/FromDoppler/Wordpress-Plugin-Doppler/assets/34007887/ae1d5f13-96e7-4a8c-81d2-1805b498427a)
