### PR TITLE
[DOW-7] Fix bug when submitting doble optin with error

### DIFF
--- a/admin/js/doppler-form-admin.js
+++ b/admin/js/doppler-form-admin.js
@@ -397,6 +397,10 @@
 		$('input[name="name"]').on("change", function () {
 			$("#form_name").val($(this).val());
 		});
+
+		if ($('input[name="name"]').val()) {
+			$("#form_name").val($('input[name="name"]').val());
+		}
 	});
 
 	function listsLoading() {


### PR DESCRIPTION
When submitting a doble optin form with a wrong field value it would return to the creation screen but with the form name emprty.
Since it's a hidden value it was failing and the user wouldn't know why.