### PR TITLE
[DOW-5] Remove &nbsp translation

### DIFF
--- a/admin/partials/forms-edit.php
+++ b/admin/partials/forms-edit.php
@@ -333,8 +333,8 @@ window.onload = function(){
 
 String.prototype.replaceHtmlEntites = function() {
   var s = this;
-  var translate_re = /&(nbsp|amp|quot|lt|gt);/g;
-  var translate = {"nbsp": " ","amp" : "&","quot": "\"","lt"  : "<","gt"  : ">"};
+  var translate_re = /&(amp|quot|lt|gt);/g;
+  var translate = {"amp" : "&","quot": "\"","lt"  : "<","gt"  : ">"};
   return ( s.replace(translate_re, function(match, entity) {
     return translate[entity];
   }) );


### PR DESCRIPTION
The nbsp lines added by the editor were being replace by empty strings. Now those lines will remain unmodified