### PR TITLE
[DOW-94] Rename honey pot field to avoid browser autocompletion

### DIFF
--- a/includes/helpers/Form_Helper.php
+++ b/includes/helpers/Form_Helper.php
@@ -91,7 +91,7 @@ class DPLR_Form_helper
 					<?php endif; ?>
 				</div>
 			<?php endif; ?>
-			<input type="text" name="secondary-dplrEmail" value="" class="dplr-secondary-email"/>
+			<input type="text" name="dplr-hp-field" value="" tabindex="-1" autocomplete="off" class="dplr-hp-field"/>
 			<label class="msg-data-sending"><?php echo isset($form->settings["message_success"]) ? $form->settings["message_success"] : __('Thanks for subscribing', 'doppler-form'); ?></label>
 			<div class="input-button">
 				<button type="submit" name="submit" class="<?php echo isset($form->settings["button_position"]) ? $form->settings["button_position"] : 'left'; ?>">

--- a/public/css/doppler-form-public.css
+++ b/public/css/doppler-form-public.css
@@ -3,7 +3,7 @@ form.dplr_form {
 	border-bottom: 1px solid #797979;
 	padding: 20px 0;
 }
-form.dplr_form .dplr-secondary-email {
+form.dplr_form .dplr-hp-field {
 	opacity: 0;
 	position: absolute;
 	top: 0;

--- a/public/css/doppler-form-public.scss
+++ b/public/css/doppler-form-public.scss
@@ -3,7 +3,7 @@ form.dplr_form {
 	border-bottom: 1px solid rgb(121, 121, 121);
 	padding: 20px 0;
 
-	.dplr-secondary-email {
+	.dplr-hp-field {
 		opacity: 0;
 		position: absolute;
 		top: 0;

--- a/public/js/doppler-form-public.js
+++ b/public/js/doppler-form-public.js
@@ -13,7 +13,7 @@
 		var l = form.find("input[name='list_id']");
 		var d = form.find("input[name='form_id']");
 		var e = form.find("input[name='EMAIL']");
-		var honey = form.find("input[name='secondary-dplrEmail']");
+		var honey = form.find("input[name='dplr-hp-field']");
 		var thankyou = form.find("input[name='thankyou']");
 		let form_id = d.val();
 		var fields = form.find(

--- a/public/scss/doppler-form-public.scss
+++ b/public/scss/doppler-form-public.scss
@@ -3,7 +3,7 @@ form.dplr_form {
 	border-bottom: 1px solid rgb(121, 121, 121);
 	padding: 20px 0;
 
-	.dplr-secondary-email {
+	.dplr-hp-field {
 		opacity: 0;
 		position: absolute;
 		top: 0;


### PR DESCRIPTION
A user reported issues with a form where the honey pot field is being completed.
I researched quite a bit on the web and there is a lot of people with the same issue but there is not a clear fix for this. In most of the cases not using a key name like "email" or "address" works.