### PR TITLE
[DOW-105] Fix TinyMCE confirmation link content verification

### DIFF
--- a/admin/css/doppler-form-admin.css
+++ b/admin/css/doppler-form-admin.css
@@ -1368,10 +1368,15 @@
 	border: transparent !important;
 }
 
+/* override Wordpress's styles */
 #dplr-consent-location {
 	/* override wp styles for this component*/
 	background-image: none;
 }
 #dplr-consent-text:disabled::placeholder {
 	color: #999;
+}
+
+.dplr_settings select {
+    background: white;
 }

--- a/admin/js/doppler-form-admin.js
+++ b/admin/js/doppler-form-admin.js
@@ -523,6 +523,15 @@
 				bindto: "#doppler-forms-chart"
 			});
 		}
+
+		$('#content-html').on('click', function() {
+			setTimeout(function() {
+				$('#content').off('blur').on('blur', function() {
+					var content = document.getElementById("content").value
+					validateEmailContent(null, content);
+				});
+			}, 100);
+		});
 	});
 
 	function listsLoading() {
@@ -698,14 +707,7 @@ function generateErrorMsg(body) {
 	return err;
 }
 
-function validateEmailContent(e) {
-	var content = "";
-
-	if (!tinyMCE.activeEditor)
-		jQuery(".wp-editor-wrap .switch-tmce").trigger("click");
-
-	content = tinymce.activeEditor.getContent();
-
+function validateEmailContent(e, content) {
 	content = content.replace(
 		'href="[[[ConfirmationLink]]]"',
 		"href=[[[ConfirmationLink]]]"

--- a/admin/partials/forms-create.php
+++ b/admin/partials/forms-create.php
@@ -239,8 +239,9 @@
                   'tinymce' => array(
                   'init_instance_callback' => 'function(editor) {
                               editor.on("blur", function(){
-                                validateEmailContent();
-                          });
+                                var content = tinymce.activeEditor.getContent();
+                                validateEmailContent(null, content);
+                            });
                       }'
                   )
                 );
@@ -395,7 +396,9 @@ document.getElementById('wp-content-wrap').addEventListener("click", function(){
 document.getElementById("submit_button").addEventListener("click", function(){
   document.getElementById('content').value = document.getElementById('content').value.replaceHtmlEntites();
   if(document.getElementById("settings[form_doble_optin]").value === 'yes'){
-    validateEmailContent(event);
+    jQuery(".wp-editor-wrap .switch-tmce").trigger("click");
+    var content = tinymce.activeEditor.getContent();
+    validateEmailContent(event, content);
   }
 });
 

--- a/admin/partials/forms-edit.php
+++ b/admin/partials/forms-edit.php
@@ -245,7 +245,8 @@
                     'tinymce' => array(
                     'init_instance_callback' => 'function(editor) {
                                 editor.on("blur", function(){
-                                  validateEmailContent();
+                                  var content = tinymce.activeEditor.getContent();
+                                  validateEmailContent(null, content);
                             });
                         }'
                     )
@@ -446,7 +447,9 @@ document.getElementById("submit_button").addEventListener("click", function(){
 
   document.getElementById('content').value = document.getElementById('content').value.replaceHtmlEntites();
   if(document.getElementById("settings[form_doble_optin]").value === 'yes'){
-    validateEmailContent(event);
+    jQuery(".wp-editor-wrap .switch-tmce").trigger("click");
+    var content = tinymce.activeEditor.getContent();
+    validateEmailContent(event, content);
   }
 });
 


### PR DESCRIPTION
This fixes an issue when on the "code" editor it wouldn't verify the content of the editor until the user changed to the "visual" editor.

Now it will verify content depending on the active editor and on submit it will change to the "visual" editor (updating both contents) and then will verify it's content.