### PR TITLE
[DOW-100] Try to get elementor base module for different versions

### DIFF
--- a/admin/js/doppler-elementor.js
+++ b/admin/js/doppler-elementor.js
@@ -1,20 +1,38 @@
 (function($){
   $(window).on('elementor:init', function() {
-    var BaseIntegrationModule = elementorPro.modules.forms.mailchimp.__proto__.constructor;
+    var BaseIntegrationModule = null;
 
-    var Doppler = BaseIntegrationModule.extend({
-      getName() {
-        return 'doppler';
-      },
-      getUserFields() {
-        this.getEditorControlView('doppler_fields_map').updateMap(dopplerFields);
-      },
-      onSectionActive() {
-        this.getUserFields();
+    // Elementor is constantly changing its internal JS API.
+    // We try to find the base class in a few common locations to make the integration more robust.
+    if (window.elementorPro) {
+      // Modern path (versions 3.5+)
+      if (elementorPro.modules.forms.classes && elementorPro.modules.forms.classes.Integration_Base) {
+        BaseIntegrationModule = elementorPro.modules.forms.classes.Integration_Base;
+      // Older, but common path (pre 3.5) by inferring from another integration
+      } else if (elementorPro.modules.forms.mailchimp) {
+        BaseIntegrationModule = elementorPro.modules.forms.mailchimp.__proto__.constructor;
       }
-    });
+    }
 
-    elementorPro.modules.forms.doppler = new Doppler('form');
+    if (BaseIntegrationModule) {
+      var Doppler = BaseIntegrationModule.extend({
+        getName() {
+          return 'doppler';
+        },
+        getUserFields() {
+          var controlView = this.getEditorControlView('doppler_fields_map');
+          if (controlView) {
+            controlView.updateMap(dopplerFields);
+          }
+        },
+        onSectionActive() {
+          this.getUserFields();
+        }
+      });
+      elementorPro.modules.forms.doppler = new Doppler('form');
+    } else {
+      console.error('Doppler Forms: Could not find a valid Elementor Pro form integration base class. The integration will not be available.');
+    }
   });
 
   elementor.channels.editor.on('section:activated', function(sectionName) {


### PR DESCRIPTION
After the latest version the script started throwing errors in the dev console.
Since we are using code from the Elementor's plugin that is supposed to be of internal use the might do changes that brake our script{.
For that reason I'm making the script check for elementor base module and if it's not found it will log an error but at least doesn't break the js code.